### PR TITLE
manifest: replace permission.INTERACT_ACROSS_USERS_FULL with sysui self

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -28,7 +28,7 @@
     <uses-permission android:name="android.permission.INTERNAL_SYSTEM_WINDOW" />
     <uses-permission android:name="android.permission.DEVICE_POWER" />
     <uses-permission android:name="android.permission.STATUS_BAR_SERVICE" />
-    <uses-permission android:name="android.permission.INTERACT_ACROSS_USERS_FULL" />
+    <uses-permission android:name="com.android.systemui.permission.SELF" />
 
     <!-- Sensor HAL checks for this -->
     <permission android:name="com.google.sensor.elmyra.permission.USE_RAW_SENSOR"


### PR DESCRIPTION
Workaround for binding to screenshot service on a13